### PR TITLE
Add wp-cli config

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -327,6 +327,26 @@ const createEnv = async function() {
         });
     });
 
+    // Write wp-cli config
+    console.log( "Generating wp-cli.yml file..." );
+    await new Promise( resolve => {
+        yaml(
+            path.join( envPath, 'wp-cli.yml' ),
+            {
+                ssh: 'docker-compose:www-data@phpfpm'
+            },
+            {
+                lineWidth: 500
+            },
+            function( err ) {
+                if ( err ) {
+                    console.error( err );
+                }
+                console.log( 'done' );
+                resolve();
+            }
+        );
+    });
 
     // Media proxy is selected
     if ( answers.mediaProxy === true ) {

--- a/src/create.js
+++ b/src/create.js
@@ -115,7 +115,7 @@ const createEnv = async function() {
             }
         },
         {
-			name: 'mediaProxy',
+            name: 'mediaProxy',
             type: 'confirm',
             message: "Do you want to set a proxy for media assets? (i.e. Serving /uploads/ directory assets from a production site)",
             default: false,


### PR DESCRIPTION
### Description of the Change

This PR adds a `wp-cli.yml` configuration file to the root of the repository. This makes it much more natural to write wp-cli commands as you would normally (e.g. `wp user list` instead of `10updocker wp user list`).

WP-CLI [natively supports connecting to a container via `docker-compose`](https://make.wordpress.org/cli/handbook/running-commands-remotely/#using-an-ssh-connection) which is exactly what the configuration adds.

```
~/10up/Sites/docker-test 
⚡  wp --info                               
OS:	Linux 4.9.125-linuxkit #1 SMP Fri Sep 7 08:20:28 UTC 2018 x86_64
Shell:	
PHP binary:	/usr/local/bin/php
PHP version:	7.3.1
php.ini used:	/usr/local/etc/php/php.ini
WP-CLI root dir:	phar://wp-cli.phar/vendor/wp-cli/wp-cli
WP-CLI vendor dir:	phar://wp-cli.phar/vendor
WP_CLI phar path:	/var/www/html
WP-CLI packages dir:	
WP-CLI global config:	/var/www/.wp-cli/config.yml
WP-CLI project config:	
WP-CLI version:	2.1.0
```

Running from MacOS, so you can see that wp-cli is in fact running within the docker container (`Linux 4.9.125-linuxkit`).
