### PR TITLE
explicit mysql config

### DIFF
--- a/global/config/mysql/config.cnf
+++ b/global/config/mysql/config.cnf
@@ -1,0 +1,14 @@
+[mysqld]
+
+# help ensure larger db restores succeed
+max_allowed_packet = 1G
+
+# use a conservative 50% of configured memory
+innodb_buffer_pool_size = 512M
+
+query_cache_size = 0M
+tmp_table_size = 32M
+max_heap_table_size = 32M
+query_cache_type = 0
+innodb_file_per_table
+max_connections = 20

--- a/global/docker-compose.yml
+++ b/global/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '2.4'
 services:
   # Run a local dnsmasq server for the containers that will resolve DNS queries and
   # route any *.test domains to the gateway container
@@ -23,6 +23,7 @@ services:
   mysql:
     image: mysql:5
     volumes:
+      - "./config/mysql/config.cnf:/etc/mysql/mysql.conf.d/wp-local-docker.cnf:ro"
       - "mysqlData:/var/lib/mysql"
     ports:
       - "3306:3306"
@@ -30,6 +31,8 @@ services:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: password
+    mem_limit: 1024M
+    mem_reservation: 1024M
     networks:
       - wplocaldocker
   mailcatcher:


### PR DESCRIPTION
lock the mysql container to a max of 1GB memory
tune mysql for 1GB of memory

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This change pertains to #45 and enforces a 1GB container limit for MySQL and then tunes MySQL for 1GB of memory. It also sets the max allowed packet size to 1GB to avoid issues with larger database imports.


### Benefits

Allows larger database imports to happen without issue. Should give better performance for larger databases as well. In the future will help allow the definition of minimum requirements for running wp-local-docker.

### Possible Drawbacks

This, along with a possible change to the Elasticsearch container will require changes to the default Docker Desktop config settings to increase memory set aside for Docker Desktop

### Verification Process

I ran this locally to ensure I could import a larger database and haven't had any other issues

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

#45  

### Changelog Entry

Tune MySQL container to support larger databases
