### PR TITLE
Fixed whitespace issue in CLI arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -418,6 +418,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "shell-escape": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/shell-escape/-/shell-escape-0.2.0.tgz",
+      "integrity": "sha1-aP0CXrBJC09WegJ/C/IkgLX4QTM="
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "inquirer": "^6.2.0",
     "mysql": "^2.16.0",
     "read-yaml": "^1.1.0",
+    "shell-escape": "^0.2.0",
     "sudo-prompt": "^8.2.0",
     "update-check": "^1.5.2",
     "write-yaml": "^1.0.0"

--- a/src/command-utils.js
+++ b/src/command-utils.js
@@ -3,6 +3,7 @@ const envUtils = require( './env-utils' );
 const path = require( 'path' );
 const checkForUpdate = require('update-check');
 const chalk = require( 'chalk' );
+const shellEscape = require( 'shell-escape' );
 
 const command = function() {
     let command = process.argv[2];
@@ -14,9 +15,7 @@ const command = function() {
 };
 
 const commandArgs = function() {
-    let args = Array.prototype.slice.call( process.argv, 3 ).join( ' ' );
-
-    return args;
+    return shellEscape( Array.prototype.slice.call( process.argv, 3 ) );
 };
 
 const subcommand = function() {


### PR DESCRIPTION
Fixed the issue described in #6 by escaping command line arguments using `shell-escape` library.