### PR TITLE
allow global services to listen on localhost only

### DIFF
--- a/global/docker-compose.yml
+++ b/global/docker-compose.yml
@@ -7,14 +7,17 @@ services:
     cap_add:
       - NET_ADMIN
     command: "-A /test/10.0.0.3 --log-facility=-"
+    ports:
+        - "127.0.0.1:53:53/udp"
+        - "127.0.0.1:53:53"
     networks:
       wplocaldocker:
         ipv4_address: 10.0.0.2
   gateway:
     image: 10up/nginx-proxy
     ports:
-      - "80:80"
-      - "443:443"
+      - "127.0.0.1:80:80"
+      - "127.0.0.1:443:443"
     volumes:
       - "/var/run/docker.sock:/tmp/docker.sock:ro"
     networks:
@@ -26,7 +29,7 @@ services:
       - "./config/mysql/config.cnf:/etc/mysql/mysql.conf.d/wp-local-docker.cnf:ro"
       - "mysqlData:/var/lib/mysql"
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_USER: wordpress
@@ -38,8 +41,8 @@ services:
   mailcatcher:
     image: schickling/mailcatcher
     ports:
-      - "1025:1025"
-      - "1080:1080"
+      - "127.0.0.1:1025:1025"
+      - "127.0.0.1:1080:1080"
     environment:
       MAILCATCHER_PORT: 1025
     networks:
@@ -47,7 +50,7 @@ services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     ports:
-      - "8092:80"
+      - "127.0.0.1:8092:80"
     depends_on:
       - mysql
     environment:


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

This change forces the global services to only listen on localhost on the host system. This helps ensure they are not accessible on the network.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Prevents remote access to the services

### Possible Drawbacks

Anyone who might have been relying on these services being available remotely while on a trusted network will not longer be able to access them.

### Verification Process

Using nmap from a separate computer I verified that ports/services are available prior to the change and that they were then unavailable after the change.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->
