### PR TITLE
GitHub actions to run lint command

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,22 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install and lint
+        run: |
+          npm ci
+          npm run lint --silent
+        env:
+          CI: true

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "10updocker": "node index.js",
     "10updocker-hosts": "./hosts.js",
     "lint": "eslint src/*.js src/**/*.js",
-    "lint:fix": "npm run lint -- --fix"
+    "lint:fix": "npm run lint --silent -- --fix"
   },
   "bin": {
     "10updocker": "./index.js",

--- a/src/create.js
+++ b/src/create.js
@@ -120,7 +120,7 @@ const createEnv = async function() {
         {
             name: 'addHttps',
             type: 'confirm',
-            message: "Do you want to enable HTTPS?",
+            message: 'Do you want to enable HTTPS?',
             default: false,
         },
         {


### PR DESCRIPTION
### Description of the Change

Added basic github actions to run lint command on push.

### Benefits

Even though we use the husky hook to run lint command before committing changes, there is a possibility to avoid it by using `--no-verify` flag. This github actions configuration will help us to see whether everything is fine with formatting when we are viewing a PR.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
