### PR TITLE
Github actions to release @next when something is merged into master

### DIFF
--- a/.github/workflows/npmjs.yml
+++ b/.github/workflows/npmjs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feature/at-next
 
 jobs:
   atnext:

--- a/.github/workflows/npmjs.yml
+++ b/.github/workflows/npmjs.yml
@@ -1,0 +1,21 @@
+name: Npm CI
+
+on: 
+  push:
+    branches:
+      - master
+      - feature/at-next
+
+jobs:
+  atnext:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - name: publish @next
+        run: npm publish --tag next --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Inspired by: _[Automatically Publish to npm using GitHub Actions](https://sergiodxa.com/articles/github-actions-npm-publish/)_

### Description of the Change

Added a new Github Actions configuration to automatically publish a new `@next` version to npmjs.org whevener we merge something to master. It won't break existing versions because they are tagged with `@latest` tag and will remain the same.

The `Npm CI` action depends on `NPM_TOKEN` secret variable that must generated at npmjs.com and added to this repo secret variables. See instructions [here](https://sergiodxa.com/articles/github-actions-npm-publish/#configure-the-secret).

### Benefits

Everyone can install `wp-local-docker@next` to test the latest functionality on local machines.

### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
