### PR TITLE
Auto completion script

### DIFF
--- a/hosts.js
+++ b/hosts.js
@@ -5,20 +5,22 @@ const commandUtils = require( './src/command-utils' );
 
 const add = function( hosts ) {
     hostile.set( '127.0.0.1', hosts.join(' '), function( err ) {
-        if (err) {
-            console.error(err)
+        if ( err ) {
+            console.error( err.message );
+            process.exit( err.errno );
         } else {
-            console.log('Added to hosts file successfully!')
+            console.log( 'Added to hosts file successfully!' );
         }
     });
 };
 
 const remove = function( hosts ) {
     hostile.remove( '127.0.0.1', hosts.join(' '), function( err ) {
-        if (err) {
-            console.error(err)
+        if ( err ) {
+            console.error( err.message );
+            process.exit( err.errno );
         } else {
-            console.log('Removed from hosts file successfully!')
+            console.log( 'Removed from hosts file successfully!' );
         }
     });
 };

--- a/hosts.js
+++ b/hosts.js
@@ -4,30 +4,30 @@ const hostile = require( 'hostile' );
 const commandUtils = require( './src/command-utils' );
 
 const add = function( hosts ) {
-    hostile.set( '127.0.0.1', hosts.join(' '), function( err ) {
+    hostile.set( '127.0.0.1', hosts.join( ' ' ), function( err ) {
         if ( err ) {
             console.error( err.message );
             process.exit( err.errno );
         } else {
             console.log( 'Added to hosts file successfully!' );
         }
-    });
+    } );
 };
 
 const remove = function( hosts ) {
-    hostile.remove( '127.0.0.1', hosts.join(' '), function( err ) {
+    hostile.remove( '127.0.0.1', hosts.join( ' ' ), function( err ) {
         if ( err ) {
             console.error( err.message );
             process.exit( err.errno );
         } else {
             console.log( 'Removed from hosts file successfully!' );
         }
-    });
+    } );
 };
 
 const command = function() {
-    let mode = commandUtils.command();
-    let args = commandUtils.commandArgs( false );
+    const mode = commandUtils.command();
+    const args = commandUtils.commandArgs( false );
 
     switch( mode ) {
         case 'add':
@@ -37,9 +37,10 @@ const command = function() {
             remove( args );
             break;
         default:
-            console.error( "Invalid hosts command" );
-            process.exit(1);
+            console.error( 'Invalid hosts command' );
+            process.exit( 1 );
             break;
     }
 };
+
 command();

--- a/index.js
+++ b/index.js
@@ -3,10 +3,9 @@
 const chalk = require( 'chalk' );
 const commandUtils = require( './src/command-utils' );
 const config = require( './src/configure' );
-const snapshots = require( './src/wpsnapshots' );
 
 const help = function() {
-    let help = `
+    const help = `
 Usage: 10updocker COMMAND
 
 Commands:
@@ -30,16 +29,16 @@ Run '10updocker COMMAND help' for more information on a command.
 };
 
 const version = function() {
-    var pjson = require('./package.json');
+    const pjson = require( './package.json' );
     console.log( 'WP Local Docker' );
     console.log( `Version ${pjson.version}` );
 };
 
 const init = async function() {
-    let command = commandUtils.command();
-    let configured = await config.checkIfConfigured();
-    let bypassCommands = [ undefined, 'configure', 'help', '--version', '-v' ];
-    let isBypass = bypassCommands.indexOf( command ) !== -1;
+    const command = commandUtils.command();
+    const configured = await config.checkIfConfigured();
+    const bypassCommands = [ undefined, 'configure', 'help', '--version', '-v' ];
+    const isBypass = bypassCommands.indexOf( command ) !== -1;
 
     // Configure using defaults if not configured already
     if ( configured === false && isBypass === false ) {
@@ -48,11 +47,11 @@ const init = async function() {
 
     // Don't even run the command to check if docker is running if we have one of the commands that don't need it
     if ( isBypass === false ) {
-        let isRunning = commandUtils.checkIfDockerRunning();
+        const isRunning = commandUtils.checkIfDockerRunning();
 
         // Show warning if docker isn't running
         if ( isRunning === false ) {
-            console.error( chalk.red( "Error: Docker doesn't appear to be running. Please start Docker and try again" ) );
+            console.error( chalk.red( 'Error: Docker doesn\'t appear to be running. Please start Docker and try again' ) );
             process.exit();
         }
     }
@@ -64,7 +63,7 @@ const init = async function() {
             config.command();
             break;
         case 'create':
-            await require('./src/create').command();
+            await require( './src/create' ).command();
             break;
         case 'start':
         case 'stop':
@@ -72,17 +71,17 @@ const init = async function() {
         case 'delete':
         case 'remove':
         case 'upgrade':
-            await require('./src/environment').command();
+            await require( './src/environment' ).command();
             break;
         case 'snapshots':
         case 'wpsnapshots':
-            await require('./src/wpsnapshots').command();
+            await require( './src/wpsnapshots' ).command();
             break;
         case 'cache':
-            await require('./src/cache').command();
+            await require( './src/cache' ).command();
             break;
         case 'image':
-            await require('./src/image').command();
+            await require( './src/image' ).command();
             break;
         case 'shell':
             await require( './src/shell' ).command();
@@ -105,4 +104,5 @@ const init = async function() {
             break;
     }
 };
+
 init();

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
+const path = require( 'path' );
 const chalk = require( 'chalk' );
+
 const commandUtils = require( './src/command-utils' );
 const config = require( './src/configure' );
 
@@ -34,10 +36,15 @@ const version = function() {
     console.log( `Version ${pjson.version}` );
 };
 
+const completion = function() {
+    const filename = path.resolve( __dirname, 'scripts', '10updocker-completion.bash' );
+    console.log( `source ${filename}` );
+};
+
 const init = async function() {
     const command = commandUtils.command();
     const configured = await config.checkIfConfigured();
-    const bypassCommands = [ undefined, 'configure', 'help', '--version', '-v' ];
+    const bypassCommands = [ undefined, 'configure', 'help', '--version', '-v', '--completion' ];
     const isBypass = bypassCommands.indexOf( command ) !== -1;
 
     // Configure using defaults if not configured already
@@ -54,9 +61,10 @@ const init = async function() {
             console.error( chalk.red( 'Error: Docker doesn\'t appear to be running. Please start Docker and try again' ) );
             process.exit();
         }
-    }
 
-    await commandUtils.checkForUpdates();
+        // Check for updates
+        await commandUtils.checkForUpdates();
+    }
 
     switch ( command ) {
         case 'configure':
@@ -98,6 +106,9 @@ const init = async function() {
         case '--version':
         case '-v':
             version();
+            break;
+        case '--completion':
+            completion();
             break;
         default:
             help();

--- a/package-lock.json
+++ b/package-lock.json
@@ -855,7 +855,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "10updocker": "./index.js",
     "10updocker-hosts": "./hosts.js",
-    "lint": "eslint src/*.js src/**/*.js",
+    "lint": "eslint . --ext .js --ignore-pattern node_modules",
     "lint:fix": "npm run lint --silent -- --fix"
   },
   "bin": {

--- a/scripts/10updocker-completion.bash
+++ b/scripts/10updocker-completion.bash
@@ -1,0 +1,56 @@
+#/usr/bin/env bash
+
+_10updocker_environments_completion() {
+    local cur_word="${COMP_WORDS[COMP_CWORD]}"
+    local env_utils="$( cd "$( dirname "$( dirname "${BASH_SOURCE[0]}" )" )" >/dev/null 2>&1 && pwd )"
+    local script="
+(async () => {
+    const envs = await require('${env_utils}/src/env-utils.js').getAllEnvironments().catch( () => [] );
+    process.stdout.write( ( envs || [] ).join( ' ' ) + ' all' );
+})()"
+
+    local all_envs="$(node -e "$script")"
+    COMPREPLY=($(compgen -W "${all_envs}" -- "${cur_word}"))
+}
+
+_10updocker_completion() {
+    local env_utils all_envs commands cur_word
+
+    commands="cache configure create delete remove image logs migrate restart shell start stop wp wpspanshots spanshots upgrade"
+    cur_word="${COMP_WORDS[COMP_CWORD]}"
+
+    if [ ${COMP_CWORD} -eq 1 ]; then
+        COMPREPLY=($(compgen -W "${commands}" -- "${cur_word}"))
+    elif [ ${COMP_CWORD} -eq 2 ]; then
+        case ${COMP_WORDS[1]} in
+            cache)
+                COMPREPLY=($(compgen -W "clear" -- "${cur_word}"))
+                ;;
+            image)
+                COMPREPLY=($(compgen -W "update" -- "${cur_word}"))
+                ;;
+            delete | remove | start | stop | restart)
+                _10updocker_environments_completion
+                ;;
+        esac
+    elif [ ${COMP_CWORD} -eq 3 ]; then
+        case ${COMP_WORDS[1]} in
+            migrate)
+                _10updocker_environments_completion
+                ;;
+        esac
+    fi
+
+    if [ ${#COMPREPLY[@]} -eq 0 ]; then
+        COMPREPLY=()
+    fi
+}
+
+_10updcoker_hosts_completion() {
+    if [ ${#COMP_WORDS[@]} -eq 2 ]; then
+        COMPREPLY=($(compgen -W "add remove" -- "${COMP_WORDS[COMP_CWORD]}"))
+    fi
+}
+
+complete -o default -F _10updocker_completion 10updocker
+complete -o default -F _10updcoker_hosts_completion 10updocker-hosts

--- a/scripts/10updocker-completion.bash
+++ b/scripts/10updocker-completion.bash
@@ -5,9 +5,17 @@ _10updocker_environments_completion() {
     local env_utils="$( cd "$( dirname "$( dirname "${BASH_SOURCE[0]}" )" )" >/dev/null 2>&1 && pwd )"
     local script="
 (async () => {
-    const envs = await require('${env_utils}/src/env-utils.js').getAllEnvironments().catch( () => [] );
-    process.stdout.write( ( envs || [] ).join( ' ' ) + ' all' );
-})()"
+    let envs = [];
+
+    try {
+        envs = await require('${env_utils}/src/env-utils.js').getAllEnvironments();
+    } catch( e ) {
+    }
+
+    envs.push( 'all' );
+    process.stdout.write( envs.join( ' ' ) );
+})();
+"
 
     local all_envs="$(node -e "$script")"
     COMPREPLY=($(compgen -W "${all_envs}" -- "${cur_word}"))

--- a/scripts/10updocker-completion.bash
+++ b/scripts/10updocker-completion.bash
@@ -1,7 +1,15 @@
 #/usr/bin/env bash
 
-_10updocker_environments_completion() {
+_compreply() {
+    local options="$*"
     local cur_word="${COMP_WORDS[COMP_CWORD]}"
+
+    COMPREPLY=($(compgen -W "${options}" -- "${cur_word}"))
+
+    return 0
+}
+
+_10updocker_environments_completion() {
     local env_utils="$( cd "$( dirname "$( dirname "${BASH_SOURCE[0]}" )" )" >/dev/null 2>&1 && pwd )"
     local script="
 (async () => {
@@ -17,28 +25,37 @@ _10updocker_environments_completion() {
 })();
 "
 
-    local all_envs="$(node -e "$script")"
-    COMPREPLY=($(compgen -W "${all_envs}" -- "${cur_word}"))
+    _compreply "$(node -e "$script")"
+
+    return 0
 }
 
 _10updocker_completion() {
-    local env_utils all_envs commands cur_word
-
-    commands="cache configure create delete remove image logs migrate restart shell start stop wp wpspanshots spanshots upgrade"
-    cur_word="${COMP_WORDS[COMP_CWORD]}"
+    # Unfortunately, if we want to use "wp cli completions" command, we need to execute this command within a container,
+    # but we don't know which environment we need to use and whether it is started or not. So we fallback to the list of 
+    # main commands defined on the official site: https://developer.wordpress.org/cli/commands/
+    local wp_commands=(
+        "admin" "cache" "cap" "cli" "comment" "config" "core" "cron" "db" "dist-archive" "embed" "eval" "eval-file"
+        "export" "find" "help" "i18n" "import" "language" "maintenance-mode" "media" "menu" "network" "option" "package"
+        "plugin" "post" "post-type" "profile" "rewrite" "role" "scaffold" "search-replace" "server" "shell" "sidebar"
+        "site" "super-admin" "taxonomy" "term" "theme" "transient" "user" "widget"
+    )
 
     if [ ${COMP_CWORD} -eq 1 ]; then
-        COMPREPLY=($(compgen -W "${commands}" -- "${cur_word}"))
+        _compreply cache configure create delete remove image logs migrate restart shell start stop wp wpspanshots spanshots upgrade
     elif [ ${COMP_CWORD} -eq 2 ]; then
         case ${COMP_WORDS[1]} in
             cache)
-                COMPREPLY=($(compgen -W "clear" -- "${cur_word}"))
+                _compreply clear
                 ;;
             image)
-                COMPREPLY=($(compgen -W "update" -- "${cur_word}"))
+                _compreply update
                 ;;
             delete | remove | start | stop | restart)
                 _10updocker_environments_completion
+                ;;
+            wp)
+                _compreply "${wp_commands[@]}"
                 ;;
         esac
     elif [ ${COMP_CWORD} -eq 3 ]; then
@@ -46,18 +63,229 @@ _10updocker_completion() {
             migrate)
                 _10updocker_environments_completion
                 ;;
+            wp)
+                case ${COMP_WORDS[2]} in
+                    cache)
+                        _compreply add decr delete flush get incr replace set type
+                        ;;
+                    cap)
+                        _compreply add list remove
+                        ;;
+                    cli)
+                        _compreply alias cache check-update cmd-dump completions has-command info param-dump update version
+                        ;;
+                    comment)
+                        _compreply approve count create delete exists generate get list meta recount spam status trash unapprove unspam untrash update
+                        ;;
+                    config)
+                        _compreply create delete edit get has list path set shuffle-salts
+                        ;;
+                    core)
+                        _compreply check-update download install is-installed multisite-install multisite-convert update update-db verify-checksums version
+                        ;;
+                    cron)
+                        _compreply event schedule test
+                        ;;
+                    db)
+                        _compreply check clean cli columns create drop export import optimize prefix query repair reset search size tables
+                        ;;
+                    embed)
+                        _compreply cache fetch handler provider
+                        ;;
+                    i18n)
+                        _compreply make-json make-pot
+                        ;;
+                    language)
+                        _compreply core plugin theme
+                        ;;
+                    maintenance-mode)
+                        _compreply activate deactivate is-active status
+                        ;;
+                    media)
+                        _compreply fix-orientation image-size import regenerate
+                        ;;
+                    menu)
+                        _compreply create delete item list location
+                        ;;
+                    network)
+                        _compreply meta
+                        ;;
+                    option)
+                        _compreply add delete get list patch pluck update
+                        ;;
+                    package)
+                        _compreply browse install list path uninstall update
+                        ;;
+                    plugin)
+                        _compreply activate deactivate delete get install uninstall is-active is-installed list path search status toggle uninstall update verify-checksums
+                        ;;
+                    post)
+                        _compreply create delete edit exists generate get list meta term update
+                        ;;
+                    post-type)
+                        _compreply get list
+                        ;;
+                    profile)
+                        _compreply eval eval-file hook stage
+                        ;;
+                    rewrite)
+                        _compreply flush list structure
+                        ;;
+                    role)
+                        _compreply create delete exists list reset
+                        ;;
+                    scaffold)
+                        _compreply block child-theme plugin plugin-tests post-type taxonomy theme-tests
+                        ;;
+                    sidebar)
+                        _compreply list
+                        ;;
+                    site)
+                        _compreply activate archive create deactivate delete empty list mature meta option private public spam switch-language unarchive unmature unspam
+                        ;;
+                    super-admin)
+                        _compreply add list remove
+                        ;;
+                    taxonomy)
+                        _compreply get list
+                        ;;
+                    term)
+                        _compreply create delete generate get list meta migrate recount update
+                        ;;
+                    theme)
+                        _compreply activate delete disable enable get install is-active is-installed list mod path search status update
+                        ;;
+                    transient)
+                        _compreply delete get list set type
+                        ;;
+                    user)
+                        _compreply add-cap add-role check-password create delete generate get import-csv list list-caps meta remove-cap remove-role reset-password session spam term unspam update
+                        ;;
+                    widget)
+                        _compreply add deactivate delete list move reset update
+                        ;;
+                esac
+                ;;
+        esac
+    elif [ ${COMP_CWORD} -eq 4 -a ${COMP_WORDS[1]} == "wp" ]; then
+        case ${COMP_WORDS[2]} in
+            cli)
+                case ${COMP_WORDS[3]} in
+                    alias)
+                        _compreply add delete get list update
+                        ;;
+                    cache)
+                        _compreply clear prune
+                        ;;
+                esac
+                ;;
+            comment)
+                case ${COMP_WORDS[3]} in
+                    meta)
+                        _compreply add delete get list patch pluck update
+                        ;;
+                esac
+                ;;
+            cron)
+                case ${COMP_WORDS[3]} in
+                    event)
+                        _compreply delete list run schedule
+                        ;;
+                    schedule)
+                        _compreply list
+                        ;;
+                esac
+                ;;
+            emebd)
+                case ${COMP_WORDS[3]} in
+                    cache)
+                        _compreply clear find trigger
+                        ;;
+                    handler)
+                        _compreply list
+                        ;;
+                    provider)
+                        _compreply list match
+                        ;;
+                esac
+                ;;
+            language)
+                case ${COMP_WORDS[3]} in
+                    core)
+                        _compreply activate install is-installed list uninstall update
+                        ;;
+                    plugin | theme)
+                        _compreply install is-installed list uninstall update
+                        ;;
+                esac
+                ;;
+            network)
+                case ${COMP_WORDS[3]} in
+                    meta)
+                        _compreply add delete get list patch pluck update
+                        ;;
+                esac
+                ;;
+            post)
+                case ${COMP_WORDS[3]} in
+                    meta)
+                        _compreply add delete get list patch pluck update
+                        ;;
+                    term)
+                        _compreply add list remove set
+                        ;;
+                esac
+                ;;
+            site)
+                case ${COMP_WORDS[3]} in
+                    meta | option)
+                        _compreply add delete get list patch pluck update
+                        ;;
+                esac
+                ;;
+            term)
+                case ${COMP_WORDS[3]} in
+                    meta)
+                        _compreply add delete get list patch pluck update
+                        ;;
+                esac
+                ;;
+            theme)
+                case ${COMP_WORDS[3]} in
+                    mod)
+                        _compreply get list remove set
+                        ;;
+                esac
+                ;;
+            user)
+                case ${COMP_WORDS[3]} in
+                    meta)
+                        _compreply add delete get list patch pluck update
+                        ;;
+                    session)
+                        _compreply destroy list
+                        ;;
+                    term)
+                        _compreply add list remove set
+                        ;;
+                esac
+                ;;
         esac
     fi
 
     if [ ${#COMPREPLY[@]} -eq 0 ]; then
         COMPREPLY=()
     fi
+
+    return 0
 }
 
 _10updcoker_hosts_completion() {
     if [ ${#COMP_WORDS[@]} -eq 2 ]; then
         COMPREPLY=($(compgen -W "add remove" -- "${COMP_WORDS[COMP_CWORD]}"))
     fi
+
+    return 0
 }
 
 complete -o default -F _10updocker_completion 10updocker

--- a/src/env-utils.js
+++ b/src/env-utils.js
@@ -21,7 +21,7 @@
 const slugify = require( '@sindresorhus/slugify' );
 const path = require( 'path' );
 const config = require( './configure' );
-const rootPath = path.dirname( require.main.filename );
+const rootPath = path.dirname( __dirname );
 const srcPath = path.join( rootPath, 'src' );
 const cacheVolume = 'wplocaldockerCache';
 const globalPath = path.join( rootPath, 'global' );


### PR DESCRIPTION
### Description of the Change

Added auto completion script which will help engineers to type `10updocker` and `10updocker-hosts` commands faster. Additionally, it also can suggest environments available on the computer.

To install auto completion script, a user needs to run the following:

```sh-session
$ 10updocker --completion >> ~/.bashrc
$ source ~/.bashrc
```

### Checklist:

- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.
