### PR TITLE
Allow to pass environment variable

### DIFF
--- a/src/env-utils.js
+++ b/src/env-utils.js
@@ -45,6 +45,16 @@ const envPath = async function( env ) {
     return envPath;
 };
 
+const parseEnvFromENV = async function() {
+    const envSlug = process.env.ENV;
+
+    if ( envSlug === undefined ) {
+        return false;
+    }
+
+    return envSlug;
+};
+
 const parseEnvFromCWD = async function() {
     // Compare both of these as all lowercase to account for any misconfigurations
     let cwd = process.cwd().toLowerCase();
@@ -123,7 +133,11 @@ const promptEnv = async function() {
 };
 
 const parseOrPromptEnv = async function () {
-    let envSlug = await parseEnvFromCWD();
+    let envSlug = await parseEnvFromENV();
+
+    if ( envSlug === false ) {
+        envSlug = await parseEnvFromCWD();
+    }
 
     if ( envSlug === false ) {
         envSlug = await promptEnv();
@@ -177,4 +191,4 @@ const createDefaultProxy = function( value ) {
     return proxyUrl;
 };
 
-module.exports = { rootPath, srcPath, sitesPath, cacheVolume, globalPath, envSlug, envPath, parseEnvFromCWD, getAllEnvironments, promptEnv, parseOrPromptEnv, getEnvHosts, getPathOrError, createDefaultProxy };
+module.exports = { rootPath, srcPath, sitesPath, cacheVolume, globalPath, envSlug, envPath, parseEnvFromENV, parseEnvFromCWD, getAllEnvironments, promptEnv, parseOrPromptEnv, getEnvHosts, getPathOrError, createDefaultProxy };

--- a/src/env-utils.js
+++ b/src/env-utils.js
@@ -52,6 +52,13 @@ const parseEnvFromENV = async function() {
         return false;
     }
 
+    // Make sure that a .config.json file exists here
+    const configFile = path.join( await envPath( envSlug ), '.config.json' );
+
+    if ( ! await fs.exists( configFile ) ) {
+        return false;
+    }
+
     return envSlug;
 };
 

--- a/src/env-utils.js
+++ b/src/env-utils.js
@@ -55,7 +55,7 @@ const parseEnvFromENV = async function() {
     // Make sure that a .config.json file exists here
     const configFile = path.join( await envPath( envSlug ), '.config.json' );
 
-    if ( ! await fs.exists( configFile ) ) {
+    if ( ! await fs.pathExists( configFile ) ) {
         return false;
     }
 


### PR DESCRIPTION
### Description of the Change

Allow to pass environment variable into nodeJS env. So we don't have to change into working directory to run the command.

For example:
```
ENV=wp.test 10updocker wp option get siteurl
```

### Benefits

Allow us to write an automation script without the needs to change directory.

### Possible Drawbacks

N/A

### Verification Process

These changes have a backward compatibility, if the ENV variable not passed then it will run as usual.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

<!-- Add sample CHANGELOG.md entry for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related. -->

* Added capability to pass `ENV` variable to run the subcommand without change directory
