### PR TITLE
Java memory increase

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -326,7 +326,7 @@ const createEnv = async function() {
             'mem_limit': '1024M',
             'mem_reservation': '1024M',
             'environment': {
-                ES_JAVA_OPTS: '-Xms450m -Xmx450m'
+                ES_JAVA_OPTS: '-Xms512m -Xmx512m'
             }
         };
 

--- a/src/create.js
+++ b/src/create.js
@@ -323,8 +323,8 @@ const createEnv = async function() {
                 './config/elasticsearch/plugins:/usr/share/elasticsearch/plugins:cached',
                 'elasticsearchData:/usr/share/elasticsearch/data:delegated'
             ],
-            'mem_limit': '1024M',
-            'mem_reservation': '1024M',
+            'mem_limit': '1280M',
+            'mem_reservation': '1280M',
             'environment': {
                 ES_JAVA_OPTS: '-Xms512m -Xmx512m'
             }


### PR DESCRIPTION
As per my proposal in this issue: https://github.com/10up/wp-local-docker-v2/issues/131

<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change

Suggesting to increase the RAM allocated to Java from 450 to 512mb, since I was manually indexing some PDF books requires more memory. A java error fires in ElasticSeach's docker container specifically indicating memory shortage. Then the container crashes. But after I manually made it 512mb indexing went well.

I am not sure if the crash is provoked by the total number of books, or the heaviness of a single book. I am indexing 107 books now.

### Alternate Designs

I don't see any

### Benefits

ElasticSearch won't crash when indexing a hundred  PDF book attachments.

### Possible Drawbacks

I don't see any

### Verification Process

- I manually updated the limit to 512 in the local .yml file, then
- `ran 10updocker restart all` command in the terminal
- ran manual sync in the ElasticPress plugin and it went through without errors

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

### Changelog Entry

Java memory increased in ElasticSearch container
