### PR TITLE
Update the URL output in `list` command

### DIFF
--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -4,6 +4,7 @@
 const { table } = require( 'table' );
 const chalk = require( 'chalk' );
 const logSymbols = require( 'log-symbols' );
+const terminalLink = require( 'terminal-link' );
 
 /**
  * Internal dependencies.
@@ -30,16 +31,16 @@ exports.handler = makeCommand( chalk, logSymbols, async () => {
 
         // Get current environment host name, use the starting index.
         const envHosts = await envUtils.getEnvHosts( envPath );
-        const hostName = envHosts[0];
+        const hostName = `http://${ envHosts[0] }/`;
 
         try {
             const containers = await docker.listContainers( { filters: { 'name': [ envSlug ] } } );
 
             // Check containers availability and push to list with appropriate status.
             if ( Array.isArray( containers ) && containers.length ) {
-                envStatus.push( [ envSlug, 'UP', hostName ] );
+                envStatus.push( [ envSlug, 'UP', terminalLink( chalk.cyanBright( hostName ), hostName ) ] );
             } else {
-                envStatus.push( [ envSlug, 'DOWN', hostName ] );
+                envStatus.push( [ envSlug, 'DOWN', terminalLink( chalk.cyanBright( hostName ), hostName ) ] );
             }
         } catch( ex ) {
             console.error( ex );


### PR DESCRIPTION
### Description of the Change

This is a minor upgrade to the newly added `list` command, it uses the `terminalLink` package which improves the URL output and converts it into a link similar to the output of the `start` command.

### Benefits

The change provides better output and improves the current experience

### Verification Process

- Run `npm run 10updocker ls`
![image](https://user-images.githubusercontent.com/13589980/89106726-f8cb5e00-d449-11ea-84be-fc7cd67953aa.png)

### Checklist:

- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.

### Applicable Issues

Related https://github.com/10up/wp-local-docker-v2/issues/122