### PR TITLE
Add `zsh` completion using script generated by `yargs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file, per [the Ke
 ## [2.8.0] - TBD
 ### Added
 - Adds `clone` command to clone git repositories and create new environments for it.
-- Adds `completion <shell>` command to display instructions how to activate autocomplete for a specific shell. Currently only `bash` is supported.
+- Adds `completion <shell>` command to display instructions how to activate autocomplete for a specific shell. Supported shells : `bash` and `zsh`.
 - Adds the ability to use project specific configuration files. It is read during clonning process and allows to define a configuration required for the project and allows to omit setup questions. If the configuration is not sufficient (for example, it misses php version), then appropriate questions will be asked fill gaps.
 - Adds `init` command to generate project configuration files.
 - Adds the ability to update a docker-compose config for an environment if the configuration file contains `dockerCompose` callback function.
@@ -115,7 +115,7 @@ opcache configured with optimal settings for development.
 
 ## [2.3.0] - 2019-02-22
 ### Added
-- Adds prompt for proxying images from another site. Props @TylerB24890 
+- Adds prompt for proxying images from another site. Props @TylerB24890
 
 ### Changed
 - Updates lodash to latest version to fix vulnerability in the package

--- a/scripts/10updocker-completion.zsh
+++ b/scripts/10updocker-completion.zsh
@@ -15,3 +15,21 @@ _10updocker_yargs_completions()
 }
 compdef _10updocker_yargs_completions 10updocker
 ###-end-10updocker-completions-###
+
+###-begin-10updocker-hosts-completions-###
+#
+# yargs command completion script
+#
+# Installation: 10updocker-hosts completion >> ~/.zshrc
+#
+_10updocker-hosts_yargs_completions()
+{
+  local reply
+  local si=$IFS
+  IFS=$'
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" 10updocker-hosts --get-yargs-completions "${words[@]}"))
+  IFS=$si
+  _describe 'values' reply
+}
+compdef _10updocker-hosts_yargs_completions 10updocker-hosts
+###-end-10updocker-hosts-completions-###

--- a/scripts/10updocker-completion.zsh
+++ b/scripts/10updocker-completion.zsh
@@ -1,0 +1,17 @@
+###-begin-10updocker-completions-###
+#
+# yargs command completion script
+#
+# Installation: 10updocker completion zsh >> ~/.zshrc
+#
+_10updocker_yargs_completions()
+{
+  local reply
+  local si=$IFS
+  IFS=$'
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" 10updocker --get-yargs-completions "${words[@]}"))
+  IFS=$si
+  _describe 'values' reply
+}
+compdef _10updocker_yargs_completions 10updocker
+###-end-10updocker-completions-###

--- a/src/commands/completion.js
+++ b/src/commands/completion.js
@@ -25,10 +25,14 @@ exports.handler = ( { shell } ) => {
 			console.log( `source ${ filename }` );
 			break;
 		}
-		case 'zsh':
-			console.error( chalk.red( 'ZSH is not supported yet.' ) );
-			process.exit( 2 );
+		case 'zsh': {
+			const filename = resolve( __dirname, '../../scripts/10updocker-completion.zsh' );
+			console.log( '###-begin wp-local-docker command completion script for zsh-###' );
+			console.log( `# Installation: ${ chalk.bold.cyan( '10updocker completion zsh >> ~/.zshrc' ) }` );
+			console.log( '###-end wp-local-docker command completion script for zsh-###' );
+			console.log( `source ${ filename }` );
 			break;
+		}
 		default:
 			console.error( `${ chalk.bold.redBright( shell ) } ${ chalk.red( 'shell is not supported.' ) }` );
 			process.exit( 1 );


### PR DESCRIPTION
### Description of the Change

Adds support for command completion on `zsh`

![zsh_preview](https://user-images.githubusercontent.com/13589980/90028825-c508f780-dcd7-11ea-9d65-4f5795f75fc8.gif)


### Benefits

- Provides a better working experience on `zsh`

### Possible Drawbacks

- Doesn't support `wp` subcommand completion.

### Verification Process

- Source the completion script and type `10updocker` and press <kbd>TAB</kbd>

### Checklist:

- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [X] All new and existing tests passed.
