### PR TITLE
update decraped dnsmasq image

### DIFF
--- a/global/docker-compose.yml
+++ b/global/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # Run a local dnsmasq server for the containers that will resolve DNS queries and
   # route any *.test domains to the gateway container
   dns:
-    image: andyshinn/dnsmasq
+    image: 4km3/dnsmasq:latest
     cap_add:
       - NET_ADMIN
     command: -A /test/10.0.0.3 --log-facility=-


### PR DESCRIPTION
### Description of the Change

I using a Mac with M1 arch. So, i check the global container and i see the current `dnsmasq` dont have support to arm64 arch. And it can be generate a consuming memory issue of using Rosetta to emulate.

So when i check the default image on hub.docker [andyshinn/dnsmasq](https://hub.docker.com/r/andyshinn/dnsmasq) has a message informing this image are moved to [4km3/dnsmasq](https://hub.docker.com/r/4km3/dnsmasq). And this new image has support to arm64!

### Alternate Designs

n/a, these are better

### Possible Drawbacks

n/a

### Verification Process

Checked in my local container (Macbook M1).

### Checklist:

- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry
> Deprecated - andyshinn/dnsmasq image moved to 4km3/dnsmasq.

### Credits
n/a
