### PR TITLE
Update Linux section on Readme!

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Setup c compilers & add sudo user to docker group:
 
 ```
 sudo apt install -y gcc make
- sudo usermod -a -G docker user
+sudo usermod -a -G docker user
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ cp /mnt/c/Users/USER-NAME/.ssh/id_rsa* .
 Docker has platform specific installation instructions available for linux on their [documentation site](https://docs.docker.com/install/#supported-platforms).
 Once docker is installed, you will need to [manually install docker compose](https://docs.docker.com/compose/install/).
 NodeJS can be installed via a package manager for many linux platforms [following these instructions](https://nodejs.org/en/download/package-manager/).
+Setup c compilers & add sudo user to docker group:
+
+```
+sudo apt install -y gcc make
+ sudo usermod -a -G docker user
+```
 
 ---
 ## Installation


### PR DESCRIPTION
###Descript for requirements###
In order to setup 10updocker on ubuntu, the user must be added in docker group since when you install wp-local-docker using npm it checks the docker service via the user that installs it. Since the user is not the direct root user due to which it doesn't detect the docker process and setup gets failed with error `Docker is not running`. In addition to that, the c compilers are necessary to compile the installation process.