### PR TITLE
Allow selecting PHP 8.1

### DIFF
--- a/src/commands/create/inquirer.js
+++ b/src/commands/create/inquirer.js
@@ -2,6 +2,7 @@ const { validateNotEmpty, parseHostname, parseProxyUrl } = require( '../../promp
 const { createDefaultProxy } = require( '../../env-utils' );
 
 const phpVersions = [
+	'8.1',
 	'8.0',
 	'7.4',
 	'7.3',

--- a/src/docker-images.js
+++ b/src/docker-images.js
@@ -7,6 +7,7 @@ exports.globalImages = {
 };
 
 exports.images = {
+	'php8.1': '10up/wp-php-fpm-dev:8.1-ubuntu',
 	'php8.0': '10up/wp-php-fpm-dev:8.0-ubuntu',
 	'php7.4': '10up/wp-php-fpm-dev:7.4-ubuntu',
 	'php7.3': '10up/wp-php-fpm-dev:7.3-ubuntu',


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

I noticed that 10up/wp-php-fpm-dev:8.1-ubuntu is available. While it's easy to switch to 8.1. by editing docker-composer.yml and restarting, this PR would make things a little quicker.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #316 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Check out this branch. Run `npm install` and `node . create`.

After creating a site, verify that it's running PHP 8.1.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability

Adds PHP 8.1 support.

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
