### PR TITLE
Add sudo to postinstall so that mkcert doesn't get hung up

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"hosts.js"
 	],
 	"scripts": {
-		"postinstall": "npm run 10updocker postinstall --silent",
+		"postinstall": "sudo npm run 10updocker postinstall --silent",
 		"10updocker": "./index.js",
 		"10updocker-hosts": "./hosts.js",
 		"lint": "eslint . --ext .js --ignore-pattern node_modules",


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

This fixes an issue where, on MacOS Ventura (possibly others), if `~/Library/Application Support/mkcert/rootCA.pem` doesn't already exist, a hidden `sudo` prompt occurs, and the installation hangs forever.

I attempted to use the `sudo.exec()` method, but it causes an error to be thrown - `SecTrustSettingsSetTrustSettings: The authorization was denied since no user interaction was possible` - which seems related to this https://developer.apple.com/forums/thread/671582 .

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Be on a Mac, running Ventura.
2. Delete `~/Library/Application Support/mkcert/` from your computer.
3. Run `sudo -k` to make sure sudo isn't cached.
4. Run `npm uninstall -g wp-local-docker` to fully remove it.
5. Run `npm i -g wp-local-docker` to install it from the NPM Registry. Note that after a few mins it just stops. Behind the scenes it's waiting for a `sudo` password.

To test this branch:
1. Repeat steps 1-4 above.
2. Switch to this branch and `cd` to the root of this repo.
3. Edit `src/commands/postinstall.js` and comment out the `return` statement on line 16. If you don't do this, the local installation will exit before making it to the problem command.
4. Run `npm i`. You will be prompted for your `sudo` password when `npm run postinstall` is executed, and this will carry through to the `mkcert` command.
5. Once complete, verify that you have `~/Library/Application Support/mkcert/rootCA.pem`.

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Installation from NPM Registry would sometimes hang on `mkcert`


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @ggutenberg 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
