### PR TITLE
Add newer php versions for selection

### DIFF
--- a/src/commands/create/inquirer.js
+++ b/src/commands/create/inquirer.js
@@ -2,6 +2,8 @@ const { validateNotEmpty, parseHostname, parseProxyUrl } = require( '../../promp
 const { createDefaultProxy } = require( '../../env-utils' );
 
 const phpVersions = [
+	'8.2',
+	'8.1',
 	'8.0',
 	'7.4',
 	'7.3',

--- a/src/commands/init/inquirer.js
+++ b/src/commands/init/inquirer.js
@@ -42,7 +42,7 @@ module.exports = function makeInquirer( inquirer ) {
 				name: 'phpVersion',
 				type: 'list',
 				message: 'What version of PHP would you like to use?',
-				choices: [ '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ],
+				choices: [ '8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ],
 				default: '7.4',
 			},
 			{

--- a/src/docker-images.js
+++ b/src/docker-images.js
@@ -7,6 +7,8 @@ exports.globalImages = {
 };
 
 exports.images = {
+	'php8.2': '10up/wp-php-fpm-dev:8.2-ubuntu',
+	'php8.1': '10up/wp-php-fpm-dev:8.1-ubuntu',
 	'php8.0': '10up/wp-php-fpm-dev:8.0-ubuntu',
 	'php7.4': '10up/wp-php-fpm-dev:7.4-ubuntu',
 	'php7.3': '10up/wp-php-fpm-dev:7.3-ubuntu',


### PR DESCRIPTION
### Description of the Change
Adds the option to select PHP 8.1 or 8.2 when creating a new local docker site.

Closes #332
Closes #316
Supersedes #319

### How to test the Change
Check out this branch. Run npm install and node . create.

After creating a site, verify that it's running PHP 8.1 or 8.2

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Added - PHP 8.1 and 8.2 options


### Credits

Props @johnwatkins0 @darylldoyle 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
