### PR TITLE
Fix issue where 10updocker fails to add custom domain entries in `/etc/hosts`.

### DIFF
--- a/src/certificates.js
+++ b/src/certificates.js
@@ -9,12 +9,12 @@ const envUtil = require( './env-utils' );
 const { getSslCertsDirectory } = require( './configure' );
 
 function getCARoot() {
-	return execSync( `${ mkcertPrebuilt } -CAROOT`, { encoding: 'utf-8' } ).trim();
+	return execSync( `"${ mkcertPrebuilt }" -CAROOT`, { encoding: 'utf-8' } ).trim();
 }
 
 function installCA( verbose = false ) {
 	try {
-		execSync( `${ mkcertPrebuilt } -install`, {
+		execSync( `"${ mkcertPrebuilt }" -install`, {
 			stdio: verbose ? 'inherit' : 'ignore',
 		} );
 	} catch ( err ) {

--- a/src/commands/create/update-hosts.js
+++ b/src/commands/create/update-hosts.js
@@ -13,7 +13,7 @@ module.exports = function makeUpdateHosts( which, sudo, spinner ) {
 		const hostsScript = join( resolve( __dirname, '../../..' ), 'hosts.js' );
 
 		await new Promise( ( resolve ) => {
-			const command = `${ node } ${ hostsScript } add ${ hosts.join( ' ' ) }`;
+			const command = `${ node } "${ hostsScript }" add ${ hosts.join( ' ' ) }`;
 			sudo.exec( command, { name: 'WP Local Docker' }, ( err ) => {
 				if ( err ) {
 					if ( spinner ) {

--- a/src/environment.js
+++ b/src/environment.js
@@ -204,7 +204,7 @@ async function deleteEnv( env, spinner ) {
 					console.log( ` - Removing ${ hostsToDelete }` );
 				}
 
-				sudo.exec( `${ node } ${ hostsScript } remove ${ hostsToDelete }`, sudoOptions, ( error, stdout ) => {
+				sudo.exec( `${ node } "${ hostsScript }" remove ${ hostsToDelete }`, sudoOptions, ( error, stdout ) => {
 					if ( error ) {
 						if ( spinner ) {
 							spinner.warn( 'Something went wrong deleting host file entries. There may still be remnants in /etc/hosts' );


### PR DESCRIPTION
### Description of the Change

Seems like the code assumes that the file path for `mkcertPrebuilt` is a valid file system path. It's not always the case.

Sometimes (as is the case in #312) the Node is installed in a directory where there's a space in the directory name. Such paths with a space in-between will break the script, if not escaped properly.

As it's rightly pointed out https://github.com/10up/wp-local-docker-v2/issues/312#issuecomment-1325528607.

I've escaped the shell binary path with double quotes so that unexpected space characters in the file path doesn't break the script.

Closes #312

### How to test the Change
Not sure. Haven't followed any testing strategy here. But happy to follow any guidance here.

### Changelog Entry
> Fixed - Bug fix #312

### Credits
Props ...


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests pass.
