### PR TITLE
Add support for docker compose v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"asyncro": "^3.0.0",
 				"boxen": "^5.0.1",
 				"chalk": "^4.1.2",
-				"docker-compose": "^0.23.13",
+				"docker-compose": "^0.24.8",
 				"dockerode": "^3.3.0",
 				"fs-extra": "^9.1.0",
 				"hostile": "^1.3.3",
@@ -50,7 +50,7 @@
 				"lint-staged": "^10.5.4"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			}
 		},
 		"node_modules/@10up/eslint-config": {
@@ -1136,14 +1136,25 @@
 			}
 		},
 		"node_modules/docker-compose": {
-			"version": "0.23.19",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.19.tgz",
-			"integrity": "sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==",
+			"version": "0.24.8",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+			"integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
 			"dependencies": {
-				"yaml": "^1.10.2"
+				"yaml": "^2.2.2"
 			},
 			"engines": {
 				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/docker-compose/node_modules/yaml": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+			"integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/docker-modem": {
@@ -4038,6 +4049,7 @@
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
 			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true,
 			"engines": {
 				"node": ">= 6"
 			}
@@ -4873,11 +4885,18 @@
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
 		},
 		"docker-compose": {
-			"version": "0.23.19",
-			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.23.19.tgz",
-			"integrity": "sha512-v5vNLIdUqwj4my80wxFDkNH+4S85zsRuH29SO7dCWVWPCMt/ohZBsGN6g6KXWifT0pzQ7uOxqEKCYCDPJ8Vz4g==",
+			"version": "0.24.8",
+			"resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+			"integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
 			"requires": {
-				"yaml": "^1.10.2"
+				"yaml": "^2.2.2"
+			},
+			"dependencies": {
+				"yaml": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+					"integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg=="
+				}
 			}
 		},
 		"docker-modem": {
@@ -7065,7 +7084,8 @@
 		"yaml": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true
 		},
 		"yargs": {
 			"version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"asyncro": "^3.0.0",
 		"boxen": "^5.0.1",
 		"chalk": "^4.1.2",
-		"docker-compose": "^0.23.13",
+		"docker-compose": "^0.24.8",
 		"dockerode": "^3.3.0",
 		"fs-extra": "^9.1.0",
 		"hostile": "^1.3.3",

--- a/src/utils/docker-compose.js
+++ b/src/utils/docker-compose.js
@@ -10,7 +10,9 @@ function interpretComposerResults( { out, err, exitCode } ) {
 
 function makeProxyFunction( fn ) {
 	return async function( ...args ) {
-		const results = await compose[ fn ]( ...args );
+		const v2Available = ( await compose.v2.version() ).exitCode === 0;
+		const latestCompose = v2Available ? compose.v2 : compose;
+		const results = await latestCompose[ fn ]( ...args );
 		return interpretComposerResults( results );
 	};
 }


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->
After updating to the latest docker on Ubuntu, the 10updocker failed to start due to  

<details>
<summary>an error about lack of `docker-compose`</summary>

<pre><code>
 Error : Starting aw-analytics-test_memcached_1 ... 
Starting aw-analytics-test_memcached_1 ... done
Recreating 55a45def43b3_aw-analytics-test_phpfpm_1 ... 

ERROR: for 55a45def43b3_aw-analytics-test_phpfpm_1  'ContainerConfig'

ERROR: for phpfpm  'ContainerConfig'
Traceback (most recent call last):
  File "/usr/bin/docker-compose", line 33, in <module>
    sys.exit(load_entry_point('docker-compose==1.29.2', 'console_scripts', 'docker-compose')())
  File "/usr/lib/python3/dist-packages/compose/cli/main.py", line 81, in main
    command_func()
  File "/usr/lib/python3/dist-packages/compose/cli/main.py", line 203, in perform_command
    handler(command, command_options)
  File "/usr/lib/python3/dist-packages/compose/metrics/decorator.py", line 18, in wrapper
    result = fn(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/compose/cli/main.py", line 1186, in up
    to_attach = up(False)
  File "/usr/lib/python3/dist-packages/compose/cli/main.py", line 1166, in up
    return self.project.up(
  File "/usr/lib/python3/dist-packages/compose/project.py", line 697, in up
    results, errors = parallel.parallel_execute(
  File "/usr/lib/python3/dist-packages/compose/parallel.py", line 108, in parallel_execute
    raise error_to_reraise
  File "/usr/lib/python3/dist-packages/compose/parallel.py", line 206, in producer
    result = func(obj)
  File "/usr/lib/python3/dist-packages/compose/project.py", line 679, in do
    return service.execute_convergence_plan(
  File "/usr/lib/python3/dist-packages/compose/service.py", line 579, in execute_convergence_plan
    return self._execute_convergence_recreate(
  File "/usr/lib/python3/dist-packages/compose/service.py", line 499, in _execute_convergence_recreate
    containers, errors = parallel_execute(
  File "/usr/lib/python3/dist-packages/compose/parallel.py", line 108, in parallel_execute
    raise error_to_reraise
  File "/usr/lib/python3/dist-packages/compose/parallel.py", line 206, in producer
    result = func(obj)
  File "/usr/lib/python3/dist-packages/compose/service.py", line 494, in recreate
    return self.recreate_container(
  File "/usr/lib/python3/dist-packages/compose/service.py", line 612, in recreate_container
    new_container = self.create_container(
  File "/usr/lib/python3/dist-packages/compose/service.py", line 330, in create_container
    container_options = self._get_container_create_options(
  File "/usr/lib/python3/dist-packages/compose/service.py", line 921, in _get_container_create_options
    container_options, override_options = self._build_container_volume_options(
  File "/usr/lib/python3/dist-packages/compose/service.py", line 960, in _build_container_volume_options
    binds, affinity = merge_volume_bindings(
  File "/usr/lib/python3/dist-packages/compose/service.py", line 1548, in merge_volume_bindings
    old_volumes, old_mounts = get_container_data_volumes(
  File "/usr/lib/python3/dist-packages/compose/service.py", line 1579, in get_container_data_volumes
    container.image_config['ContainerConfig'].get('Volumes') or {}
KeyError: 'ContainerConfig'


</code></pre>

</details>

This PR updates the npm `docker-compose` dependency to the latest version that supports docker compose v2 and makes the internal proxy use v2 if it is available.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. On the environment with docker-compose v1, run the `10updocker start`
2. Update docker compose to 2.x
3. run the `10updocker start`

### Changelog Entry

> Added - docker compose v2 support.


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
